### PR TITLE
Update (or drop) the Docker image used by Flatpak job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,6 @@ variables:
     GIT_SUBMODULE_STRATEGY: recursive
 
 flatpak:
-    image: 'registry.gitlab.gnome.org/gnome/gnome-runtime-images/gnome:master'
     variables:
         MANIFEST_PATH: "flatpak/ml.prevete.DatyNightly.json"
         FLATPAK_MODULE: "daty"


### PR DESCRIPTION
The gnome-runtime-images have been recently migrated to Quay. This is already reflected in the template.

Please note this MR has been created semi-automatically. If it doesn't make sense, feel free to close it.